### PR TITLE
feat(metrics): Implement circuit breaker for Prometheus provider

### DIFF
--- a/contracts/samples/config.yaml
+++ b/contracts/samples/config.yaml
@@ -71,6 +71,12 @@ metrics_provider:
         ttl: 5m
         max_size: 1000
 
+    # Circuit Breaker configuration (optional)
+    circuit_breaker:
+      enabled: true
+      failure_threshold: 5
+      recovery_timeout: 30s
+
     # Basic auth (optional)
     basic_auth:
       username: ${PROMETHEUS_USERNAME:-}

--- a/go-platform/README.md
+++ b/go-platform/README.md
@@ -152,6 +152,29 @@ Python 端呼叫方式（示意）：
   - 位置：`internal/pluginhost/plugins/<category>/<name>/module.card.json`
   - 驗證：`cd contracts && make validate-cards`
 
+### 可靠性與負載保護 (Reliability and Load Protection)
+
+Plugin Host 內建多種機制以確保系統穩定性與資源隔離：
+
+- **Prometheus 指標提供者熔斷 (Circuit Breaker)**：
+  - **目的**：當後端 Prometheus 服務不穩定或超載時，自動「熔斷」，暫停發送查詢，避免連鎖故障。
+  - **機制**：採用狀態機（關閉 `Closed` → 開啟 `Open` → 半開 `Half-Open`）管理。
+    - `Closed`：正常狀態，允許查詢。
+    - `Open`：連續查詢失敗達到閾值後進入此狀態，所有查詢會立即失敗，直到恢復超時。
+    - `Half-Open`：超時後進入，允許少量測試查詢。若成功則轉換回 `Closed`，若失敗則再次進入 `Open`。
+  - **設定 (`config.yaml`)**：
+    ```yaml
+    metrics_provider:
+      prometheus:
+        circuit_breaker:
+          enabled: true           # 是否啟用
+          failure_threshold: 5    # 連續失敗幾次後開啟熔斷
+          recovery_timeout: 30s   # 開啟後多久嘗試恢復 (進入半開狀態)
+    ```
+
+- **並發控制 (Concurrency Limiter)**：限制對 Prometheus 的同時查詢數量，防止其過載。
+- **查詢快取 (Query Caching)**：快取重複的指標查詢結果，降低延遲並減少後端負載。
+
 ---
 
 ## 插件開發

--- a/go-platform/internal/metrics/prometheus_provider.go
+++ b/go-platform/internal/metrics/prometheus_provider.go
@@ -16,6 +16,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// CircuitBreakerConfig 電路斷路器配置
+type CircuitBreakerConfig struct {
+	Enabled          bool          `yaml:"enabled" json:"enabled"`
+	FailureThreshold int64         `yaml:"failure_threshold" json:"failure_threshold"`
+	RecoveryTimeout  time.Duration `yaml:"recovery_timeout" json:"recovery_timeout"`
+}
+
 // PrometheusConfig Prometheus Provider 配置
 type PrometheusConfig struct {
 	// Prometheus 服務器地址
@@ -54,12 +61,40 @@ type PrometheusConfig struct {
 	Concurrency struct {
 		MaxConcurrent int `yaml:"max_concurrent" json:"max_concurrent"`
 	} `yaml:"concurrency" json:"concurrency"`
+
+	// 電路斷路器配置
+	CircuitBreaker CircuitBreakerConfig `yaml:"circuit_breaker" json:"circuit_breaker"`
 }
 
 // CachedResult 快取的查詢結果
 type CachedResult struct {
 	Result    *QueryResult
 	Timestamp time.Time
+}
+
+// CircuitBreakerState 表示電路斷路器的狀態
+type CircuitBreakerState int
+
+const (
+	// StateClosed 關閉狀態，請求正常通過
+	StateClosed CircuitBreakerState = iota
+	// StateOpen 開啟狀態，請求被阻斷
+	StateOpen
+	// StateHalfOpen 半開狀態，嘗試性地允許部分請求通過
+	StateHalfOpen
+)
+
+func (s CircuitBreakerState) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
 }
 
 // PrometheusProvider Prometheus 指標提供者
@@ -74,6 +109,12 @@ type PrometheusProvider struct {
 
 	// 並發控制
 	concurrencyLimiter chan struct{}
+
+	// 電路斷路器
+	cbState       CircuitBreakerState
+	cbFailures    int64
+	cbLastFailure time.Time
+	cbMu          sync.Mutex
 }
 
 // NewPrometheusProvider 創建 Prometheus Provider
@@ -101,6 +142,16 @@ func NewPrometheusProvider(config *PrometheusConfig, logger *zap.Logger) (*Prome
 	}
 	if config.Concurrency.MaxConcurrent == 0 {
 		config.Concurrency.MaxConcurrent = 10
+	}
+
+	// 設置電路斷路器默認值
+	if config.CircuitBreaker.Enabled {
+		if config.CircuitBreaker.FailureThreshold == 0 {
+			config.CircuitBreaker.FailureThreshold = 5
+		}
+		if config.CircuitBreaker.RecoveryTimeout == 0 {
+			config.CircuitBreaker.RecoveryTimeout = 30 * time.Second
+		}
 	}
 
 	// 創建 HTTP 客戶端
@@ -147,6 +198,7 @@ func NewPrometheusProvider(config *PrometheusConfig, logger *zap.Logger) (*Prome
 		logger:             logger,
 		cache:              make(map[string]*CachedResult),
 		concurrencyLimiter: make(chan struct{}, config.Concurrency.MaxConcurrent),
+		cbState:            StateClosed,
 	}
 
 	// 啟動快取清理 goroutine
@@ -157,8 +209,31 @@ func NewPrometheusProvider(config *PrometheusConfig, logger *zap.Logger) (*Prome
 	return provider, nil
 }
 
-// Query 執行單一指標查詢
+// Query 執行單一指標查詢，包含電路斷路器邏輯
 func (p *PrometheusProvider) Query(ctx context.Context, query MetricQuery) (*QueryResult, error) {
+	if !p.config.CircuitBreaker.Enabled {
+		return p.executeQuery(ctx, query)
+	}
+
+	// 檢查電路斷路器狀態
+	err := p.checkCircuitBreaker()
+	if err != nil {
+		return nil, err
+	}
+
+	// 執行查詢並更新斷路器狀態
+	result, err := p.executeQuery(ctx, query)
+	if err != nil {
+		p.handleFailure(err)
+		return nil, err
+	}
+
+	p.handleSuccess()
+	return result, nil
+}
+
+// executeQuery 執行實際的查詢邏輯
+func (p *PrometheusProvider) executeQuery(ctx context.Context, query MetricQuery) (*QueryResult, error) {
 	// 檢查快取
 	if p.config.Cache.Enabled {
 		if cached := p.getCachedResult(query); cached != nil {
@@ -210,6 +285,79 @@ func (p *PrometheusProvider) Query(ctx context.Context, query MetricQuery) (*Que
 	}
 
 	return queryResult, nil
+}
+
+// checkCircuitBreaker 檢查電路斷路器狀態
+func (p *PrometheusProvider) checkCircuitBreaker() error {
+	p.cbMu.Lock()
+	defer p.cbMu.Unlock()
+
+	switch p.cbState {
+	case StateOpen:
+		// 如果在開啟狀態，檢查是否可以轉換到半開狀態
+		if time.Since(p.cbLastFailure) > p.config.CircuitBreaker.RecoveryTimeout {
+			p.logger.Info("recovery timeout elapsed, transitioning to half-open state",
+				zap.Duration("recoveryTimeout", p.config.CircuitBreaker.RecoveryTimeout))
+			p.cbState = StateHalfOpen
+			p.cbFailures = 0 // 重置失敗計數器以進行半開測試
+			return nil
+		}
+		// 否則，保持開啟並返回錯誤
+		return fmt.Errorf("circuit breaker is open for metric provider")
+	case StateHalfOpen:
+		// 在半開狀態下，只允許一個請求通過
+		p.logger.Debug("circuit breaker is half-open, allowing one request")
+		return nil
+	case StateClosed:
+		// 關閉狀態，允許請求
+		return nil
+	}
+	return nil
+}
+
+// handleFailure 處理失敗的請求
+func (p *PrometheusProvider) handleFailure(err error) {
+	p.cbMu.Lock()
+	defer p.cbMu.Unlock()
+
+	// 忽略 context canceled 錯誤
+	if err == context.Canceled || err == context.DeadlineExceeded {
+		return
+	}
+
+	switch p.cbState {
+	case StateClosed:
+		p.cbFailures++
+		if p.cbFailures >= p.config.CircuitBreaker.FailureThreshold {
+			p.logger.Error("failure threshold reached, opening circuit breaker",
+				zap.Int64("failures", p.cbFailures),
+				zap.Int64("threshold", p.config.CircuitBreaker.FailureThreshold))
+			p.cbState = StateOpen
+			p.cbLastFailure = time.Now()
+		}
+	case StateHalfOpen:
+		p.logger.Warn("request failed in half-open state, re-opening circuit breaker")
+		p.cbState = StateOpen
+		p.cbLastFailure = time.Now()
+	}
+}
+
+// handleSuccess 處理成功的請求
+func (p *PrometheusProvider) handleSuccess() {
+	p.cbMu.Lock()
+	defer p.cbMu.Unlock()
+
+	switch p.cbState {
+	case StateHalfOpen:
+		p.logger.Info("request succeeded in half-open state, closing circuit breaker")
+		p.cbState = StateClosed
+		p.cbFailures = 0
+	case StateClosed:
+		// 如果之前有失敗，重置計數器
+		if p.cbFailures > 0 {
+			p.cbFailures = 0
+		}
+	}
 }
 
 // BatchQuery 並行執行多個查詢

--- a/go-platform/internal/metrics/prometheus_provider_test.go
+++ b/go-platform/internal/metrics/prometheus_provider_test.go
@@ -1,0 +1,226 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+)
+
+// mockPrometheusAPI is a mock implementation of the Prometheus API for testing.
+type mockPrometheusAPI struct {
+	v1.API
+	queryRangeFunc func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error)
+}
+
+func (m *mockPrometheusAPI) QueryRange(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+	if m.queryRangeFunc != nil {
+		return m.queryRangeFunc(ctx, query, r, opts...)
+	}
+	return nil, nil, errors.New("mock not implemented")
+}
+
+// newTestProvider creates a PrometheusProvider with a mock API for testing.
+func newTestProvider(config *PrometheusConfig, mockAPI v1.API) (*PrometheusProvider, error) {
+	if config == nil {
+		config = &PrometheusConfig{}
+	}
+	// Use NewPrometheusProvider to get default values, but then override the client.
+	provider, err := NewPrometheusProvider(config, zap.NewNop())
+	if err != nil {
+		return nil, err
+	}
+	provider.client = mockAPI
+	return provider, nil
+}
+
+func TestPrometheusProvider_CircuitBreaker_StaysClosed(t *testing.T) {
+	mockAPI := &mockPrometheusAPI{
+		queryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			return model.Matrix{}, nil, nil // Successful response
+		},
+	}
+
+	config := &PrometheusConfig{
+		CircuitBreaker: CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 3,
+			RecoveryTimeout:  1 * time.Second,
+		},
+	}
+
+	provider, err := newTestProvider(config, mockAPI)
+	assert.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		_, err := provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+		assert.NoError(t, err)
+		assert.Equal(t, StateClosed, provider.cbState)
+	}
+}
+
+func TestPrometheusProvider_CircuitBreaker_OpensOnFailure(t *testing.T) {
+	failureError := errors.New("prometheus is down")
+	mockAPI := &mockPrometheusAPI{
+		queryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			return nil, nil, failureError
+		},
+	}
+
+	config := &PrometheusConfig{
+		CircuitBreaker: CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 3,
+			RecoveryTimeout:  10 * time.Second,
+		},
+	}
+
+	provider, err := newTestProvider(config, mockAPI)
+	assert.NoError(t, err)
+
+	// Fail 3 times to open the circuit breaker
+	for i := 0; i < 3; i++ {
+		_, err := provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+		assert.Error(t, err)
+	}
+	assert.Equal(t, StateOpen, provider.cbState, "Circuit breaker should be open after 3 failures")
+
+	// The 4th call should fail immediately with a circuit breaker error
+	_, err = provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "circuit breaker is open")
+}
+
+func TestPrometheusProvider_CircuitBreaker_TransitionsToHalfOpen(t *testing.T) {
+	failureError := errors.New("prometheus is down")
+	var queryCount int
+	mockAPI := &mockPrometheusAPI{
+		queryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			queryCount++
+			return nil, nil, failureError
+		},
+	}
+
+	config := &PrometheusConfig{
+		CircuitBreaker: CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 2,
+			RecoveryTimeout:  100 * time.Millisecond,
+		},
+	}
+
+	provider, err := newTestProvider(config, mockAPI)
+	assert.NoError(t, err)
+
+	// Fail 2 times to open it
+	provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.Equal(t, StateOpen, provider.cbState)
+	assert.Equal(t, 2, queryCount)
+
+	// This call should be rejected immediately
+	provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.Equal(t, 2, queryCount)
+
+	// Wait for recovery timeout
+	time.Sleep(150 * time.Millisecond)
+
+	// The next call is the half-open attempt. It should be executed.
+	_, err = provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.Error(t, err) // It will still fail because the mock API is failing.
+	assert.Equal(t, 3, queryCount, "Query should be attempted after recovery timeout")
+
+	// After a failure in the half-open state, the breaker should re-open.
+	assert.Equal(t, StateOpen, provider.cbState, "Circuit breaker should re-open after a failed half-open attempt")
+}
+
+func TestPrometheusProvider_CircuitBreaker_ClosesOnSuccess(t *testing.T) {
+	callCount := 0
+	failureError := errors.New("prometheus is down")
+
+	mockAPI := &mockPrometheusAPI{
+		queryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			callCount++
+			if callCount <= 2 { // Fail first two times
+				return nil, nil, failureError
+			}
+			return model.Matrix{}, nil, nil // Succeed on the third call (half-open attempt)
+		},
+	}
+
+	config := &PrometheusConfig{
+		CircuitBreaker: CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 2,
+			RecoveryTimeout:  100 * time.Millisecond,
+		},
+	}
+
+	provider, err := newTestProvider(config, mockAPI)
+	assert.NoError(t, err)
+
+	// Fail twice to open
+	provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.Equal(t, StateOpen, provider.cbState)
+
+	// Wait for recovery
+	time.Sleep(150 * time.Millisecond)
+
+	// This call should be in half-open state and succeed
+	_, err = provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.NoError(t, err, "Query should succeed in half-open state")
+	assert.Equal(t, StateClosed, provider.cbState, "Circuit breaker should be closed after success in half-open")
+
+	// Subsequent calls should also succeed
+	_, err = provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.NoError(t, err)
+	assert.Equal(t, StateClosed, provider.cbState)
+}
+
+func TestPrometheusProvider_CircuitBreaker_ReOpensOnFailure(t *testing.T) {
+	callCount := 0
+	failureError := errors.New("prometheus is down")
+
+	mockAPI := &mockPrometheusAPI{
+		queryRangeFunc: func(ctx context.Context, query string, r v1.Range, opts ...v1.Option) (model.Value, v1.Warnings, error) {
+			callCount++
+			// Always fail
+			return nil, nil, failureError
+		},
+	}
+
+	config := &PrometheusConfig{
+		CircuitBreaker: CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 2,
+			RecoveryTimeout:  100 * time.Millisecond,
+		},
+	}
+
+	provider, err := newTestProvider(config, mockAPI)
+	assert.NoError(t, err)
+
+	// Fail twice to open
+	provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.Equal(t, StateOpen, provider.cbState)
+
+	// Wait for recovery
+	time.Sleep(150 * time.Millisecond)
+
+	// This call is the half-open attempt, it will fail
+	_, err = provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.Error(t, err)
+	assert.Equal(t, StateOpen, provider.cbState, "Circuit breaker should be open again after failure in half-open")
+
+	// It should still be open and reject the next call
+	_, err = provider.Query(context.Background(), MetricQuery{Metric: "test_metric"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "circuit breaker is open")
+}


### PR DESCRIPTION
This commit introduces a circuit breaker pattern to the Prometheus metrics provider to improve reliability and prevent cascading failures when the Prometheus service is unresponsive.

The circuit breaker is configurable and can be enabled or disabled. When enabled, it monitors query failures and will 'open' to stop sending requests for a configured recovery period if the failure threshold is exceeded.

Changes in this commit:
- Added circuit breaker configuration to `PrometheusConfig`.
- Implemented the circuit breaker logic with `Closed`, `Open`, and `Half-Open` states in `prometheus_provider.go`.
- Added comprehensive unit tests for the circuit breaker's state transitions.
- Updated `contracts/samples/config.yaml` with an example circuit breaker configuration.
- Updated `go-platform/README.md` to document the new feature, its purpose, and how to configure it.