### PR TITLE
Fixup: Update sample config to align with TLS changes

### DIFF
--- a/contracts/samples/config.yaml
+++ b/contracts/samples/config.yaml
@@ -24,9 +24,9 @@ grpc:
     min_time: 30s
   tls:
     enabled: false
-    cert_file: ""
-    key_file: ""
-    ca_file: ""
+    cert_path: ""
+    key_path: ""
+    ca_path: ""
 
 # ============================================
 # HTTP Configuration

--- a/contracts/schemas/config.schema.json
+++ b/contracts/schemas/config.schema.json
@@ -164,11 +164,17 @@
               "type": "boolean",
               "default": false
             },
-            "cert_file": {
-              "type": "string"
+            "cert_path": {
+              "type": "string",
+              "description": "Path to the TLS server certificate file."
             },
-            "key_file": {
-              "type": "string"
+            "key_path": {
+              "type": "string",
+              "description": "Path to the TLS server key file."
+            },
+            "ca_path": {
+              "type": "string",
+              "description": "Path to the TLS CA certificate file for mTLS."
             }
           },
           "additionalProperties": false

--- a/go-platform/README.md
+++ b/go-platform/README.md
@@ -213,9 +213,11 @@ go run tools/scaffold.go gateway/api_client
 ---
 
 ## CLI 參數（節選）
-- `--config`：指定設定檔路徑（預設依優先序自動尋找）
-- `--http-demo`：啟用示範 HTTP 服務（含 otelhttp 儀表化）
-- `--http-demo-listen`：示範 HTTP 監聽位址（預設 `:8080`）
+- `--config`：指定設定檔路徑（預設依優先序自動尋找）。
+- `--http-demo`：啟用示範 HTTP 服務（含 otelhttp 儀表化）。
+- `--http-demo-listen`：示範 HTTP 監聽位址（預設 `:7777`）。
+
+**注意**：TLS/mTLS 相關設定（憑證路徑等）已移至 `config.yaml` 的 `grpc.tls` 區塊中進行統一管理，不再支援透過 CLI 旗標設定。
 
 常用環境變數：
 ```bash

--- a/go-platform/cmd/detectviz/main.go
+++ b/go-platform/cmd/detectviz/main.go
@@ -181,13 +181,10 @@ func cmdPluginServe() {
 	waitForShutdown(ctx)
 }
 
-// ServeFlags 封裝 serve 命令的所有參數
+// ServeFlags 封装 serve 命令的所有参数
 type ServeFlags struct {
 	Listen         string
 	ConfigPath     string
-	MTLSCert       string
-	MTLSKey        string
-	MTLSCA         string
 	HTTPDemo       bool
 	HTTPDemoListen string
 }
@@ -205,9 +202,6 @@ func parseServeFlags() (*ServeFlags, error) {
 	flags := &ServeFlags{}
 	fs.StringVar(&flags.Listen, "listen", defaultListen, "ToolBridge gRPC 監聽地址")
 	fs.StringVar(&flags.ConfigPath, "config", defaultCfg, "平台設定檔 (用於 observability 等)")
-	fs.StringVar(&flags.MTLSCert, "mtls-cert", os.Getenv("DETECTVIZ_TOOLBRIDGE_TLS_CERT"), "mTLS 證書路徑")
-	fs.StringVar(&flags.MTLSKey, "mtls-key", os.Getenv("DETECTVIZ_TOOLBRIDGE_TLS_KEY"), "mTLS 私鑰路徑")
-	fs.StringVar(&flags.MTLSCA, "mtls-ca", os.Getenv("DETECTVIZ_TOOLBRIDGE_TLS_CA"), "mTLS CA 路徑")
 	fs.BoolVar(&flags.HTTPDemo, "http-demo", defaultHTTPDemo, "啟動示範 HTTP 服務 (otelhttp instrumentation)")
 	fs.StringVar(&flags.HTTPDemoListen, "http-demo-listen", defaultHTTPDemoListen, "示範 HTTP 服務監聽地址")
 
@@ -263,7 +257,7 @@ func executeStartupSequence(ctx *StartupContext, flags *ServeFlags) error {
 		zap.Duration("startup_duration", startupDuration),
 		zap.String("grpc_listen", flags.Listen),
 		zap.Bool("http_demo_enabled", flags.HTTPDemo),
-		zap.Bool("mtls_enabled", flags.MTLSCert != ""),
+		zap.Bool("mtls_enabled", ctx.Config.GRPC.TLS.Enabled),
 	)
 
 	return nil
@@ -314,7 +308,13 @@ func initObservability(ctx *StartupContext) error {
 // setupPluginSystem 設置插件系統
 func setupPluginSystem(ctx *StartupContext, flags *ServeFlags) error {
 	// 載入 TLS 配置
-	tlsCfg, err := pluginhost.LoadTLSConfig(flags.MTLSCert, flags.MTLSKey, flags.MTLSCA)
+	// loader 已根據設定中的路徑將憑證檔案讀入記憶體。
+	// 此處傳遞的是憑證的位元組內容，而非路徑。
+	tlsCfg, err := pluginhost.LoadTLSConfig(
+		ctx.Config.GRPC.TLS.CertData,
+		ctx.Config.GRPC.TLS.KeyData,
+		ctx.Config.GRPC.TLS.CAData,
+	)
 	if err != nil {
 		return fmt.Errorf("載入 mTLS 憑證失敗: %w", err)
 	}

--- a/go-platform/internal/configx/loader.go
+++ b/go-platform/internal/configx/loader.go
@@ -86,8 +86,14 @@ type Config struct {
 		MaxSendBytes int    `yaml:"max_send_bytes" json:"max_send_bytes"`
 		TLS          struct {
 			Enabled  bool   `yaml:"enabled" json:"enabled"`
-			CertFile string `yaml:"cert_file" json:"cert_file"`
-			KeyFile  string `yaml:"key_file" json:"key_file"`
+			CertPath string `yaml:"cert_path" json:"cert_path"`
+			KeyPath  string `yaml:"key_path" json:"key_path"`
+			CAPath   string `yaml:"ca_path" json:"ca_path"`
+
+			// Populated by loader, not from YAML
+			CertData []byte `yaml:"-" json:"-"`
+			KeyData  []byte `yaml:"-" json:"-"`
+			CAData   []byte `yaml:"-" json:"-"`
 		} `yaml:"tls" json:"tls"`
 	} `yaml:"grpc" json:"grpc"`
 
@@ -135,6 +141,11 @@ func LoadAndValidate(configPath string) (*Config, error) {
 	// Validate against contracts schema
 	if err := validateWithSchema(&cfg); err != nil {
 		return nil, fmt.Errorf("config validation failed: %w", err)
+	}
+
+	// Load TLS assets if paths are provided
+	if err := loadTLSAssets(&cfg); err != nil {
+		return nil, fmt.Errorf("failed to load TLS assets: %w", err)
 	}
 
 	zap.L().Info("Configuration loaded and validated",
@@ -504,6 +515,37 @@ func splitCSV(s string) []string {
 		}
 	}
 	return out
+}
+
+// loadTLSAssets 從設定中指定的路徑讀取 TLS 憑證/金鑰/CA 檔案
+func loadTLSAssets(c *Config) error {
+	if !c.GRPC.TLS.Enabled {
+		return nil
+	}
+
+	if c.GRPC.TLS.CertPath != "" && c.GRPC.TLS.KeyPath != "" {
+		certData, err := os.ReadFile(c.GRPC.TLS.CertPath)
+		if err != nil {
+			return fmt.Errorf("could not read TLS cert file %s: %w", c.GRPC.TLS.CertPath, err)
+		}
+		c.GRPC.TLS.CertData = certData
+
+		keyData, err := os.ReadFile(c.GRPC.TLS.KeyPath)
+		if err != nil {
+			return fmt.Errorf("could not read TLS key file %s: %w", c.GRPC.TLS.KeyPath, err)
+		}
+		c.GRPC.TLS.KeyData = keyData
+	}
+
+	if c.GRPC.TLS.CAPath != "" {
+		caData, err := os.ReadFile(c.GRPC.TLS.CAPath)
+		if err != nil {
+			return fmt.Errorf("could not read TLS CA file %s: %w", c.GRPC.TLS.CAPath, err)
+		}
+		c.GRPC.TLS.CAData = caData
+	}
+
+	return nil
 }
 
 // atof 解析浮點數（用於 sampling.ratio）

--- a/go-platform/internal/pluginhost/security.go
+++ b/go-platform/internal/pluginhost/security.go
@@ -7,26 +7,25 @@ import (
 	"os"
 )
 
-// LoadTLSConfig 由檔案路徑載入 mTLS 憑證。若任一為空，回傳 nil 代表使用明文（僅限開發）。
-func LoadTLSConfig(certPath, keyPath, caPath string) (*tls.Config, error) {
-	if certPath == "" || keyPath == "" {
-		return nil, nil
+// LoadTLSConfig 由憑證內容載入 mTLS 設定。若任一為空，回傳 nil 代表使用明文（僅限開發）。
+func LoadTLSConfig(certData, keyData, caData []byte) (*tls.Config, error) {
+	if len(certData) == 0 || len(keyData) == 0 {
+		return nil, nil // No cert/key provided, assuming insecure.
 	}
-	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+
+	cert, err := tls.X509KeyPair(certData, keyData)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load x509 key pair: %w", err)
 	}
+
 	var pool *x509.CertPool
-	if caPath != "" {
-		bs, err := os.ReadFile(caPath)
-		if err != nil {
-			return nil, err
-		}
+	if len(caData) > 0 {
 		pool = x509.NewCertPool()
-		if !pool.AppendCertsFromPEM(bs) {
+		if !pool.AppendCertsFromPEM(caData) {
 			return nil, fmt.Errorf("failed to append CA PEM")
 		}
 	}
+
 	return &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		ClientAuth:   tls.RequireAndVerifyClientCert,

--- a/python-adk-runtime/README.md
+++ b/python-adk-runtime/README.md
@@ -317,7 +317,7 @@ async def _robust_tool_call(self, tool: RemoteTool, params: dict, max_retries: i
 ### 連線與安全
 - 端點：`DETECTVIZ_TOOLBRIDGE_ADDR`（預設 127.0.0.1:5002）
 - 明文：`DETECTVIZ_TOOLBRIDGE_INSECURE=true`
-- TLS／mTLS：`DETECTVIZ_TOOLBRIDGE_TLS_{CERT,KEY,CA}`
+- TLS／mTLS：`DETECTVIZ_TOOLBRIDGE_TLS_{CERT,KEY,CA}_PEM` (環境變數應包含 PEM 內容，可選用 base64 編碼)
 - OTel：若安裝 OpenTelemetry，`RemoteTool` 會嘗試自動注入 `traceparent`／`tracestate`
 
 ---

--- a/python-adk-runtime/src/detectviz_adk/tools/adk_tools.py
+++ b/python-adk-runtime/src/detectviz_adk/tools/adk_tools.py
@@ -14,7 +14,7 @@ async def get_health_metrics_func(
     metrics: Optional[List[str]] = None
 ) -> Dict[str, Any]:
     """
-    [空實作] 查詢服務健康指標。直接回傳模擬的異常數據。
+    查詢服務健康指標。
     
     Args:
         service_name: 服務名稱
@@ -24,64 +24,28 @@ async def get_health_metrics_func(
     Returns:
         包含健康指標的字典
     """
-    print(f"--- [TOOL EXECUTED] get_health_metrics_func: Returning mock anomaly data for service '{service_name}'. ---")
-    
     if metrics is None:
         metrics = ["error_rate", "latency", "cpu_usage"]
+
+    remote_tool = RemoteTool(
+        tool_id="observability.health_aggregator",
+        tool_version="0.1.0"
+    )
     
-    # 模擬異常數據
-    mock_anomaly_data = {
-        "status": "success",
-        "service": service_name,
-        "time_range": time_range,
-        "data": {
-            "cpu_usage": {
-                "summary": f"服務 {service_name} 的 CPU 使用率從 20% 飆升至 95%",
-                "anomaly_detected": True,
-                "peak_value": "95%",
-                "normal_baseline": "20%"
-            },
-            "latency": {
-                "summary": f"服務 {service_name} 的 P99 請求延遲從 150ms 增加到 2500ms", 
-                "anomaly_detected": True,
-                "peak_value": "2500ms",
-                "normal_baseline": "150ms"
-            },
-            "error_rate": {
-                "summary": f"服務 {service_name} 的錯誤率從 1% 上升至 15%",
-                "anomaly_detected": True,
-                "peak_value": "15%",
-                "normal_baseline": "1%"
-            }
+    try:
+        # Go 插件期望直接的 payload，而非巢狀的 "params"
+        payload = {
+            "service_name": service_name,
+            "time_range": time_range,
+            "metrics": metrics
         }
-    }
-    
-    # 模擬網路延遲
-    await asyncio.sleep(1)
-    return mock_anomaly_data
-    
-    # 原有的 RemoteTool 程式碼保留但註解掉
-    # remote_tool = RemoteTool(
-    #     tool_id="observability.health_aggregator",
-    #     tool_version="0.1.0"
-    # )
-    # 
-    # try:
-    #     result = await remote_tool.invoke({
-    #         "action": "query_health",
-    #         "params": {
-    #             "service": service_name,
-    #             "time_range": time_range,
-    #             "metrics": metrics
-    #         }
-    #     })
-    #     return result
-    # except Exception as e:
-    #     return {
-    #         "status": "error",
-    #         "error_message": str(e),
-    #         "service": service_name
-    #     }
+        return await remote_tool.invoke(payload)
+    except Exception as e:
+        return {
+            "status": "error",
+            "error_message": str(e),
+            "service": service_name
+        }
 
 
 async def generate_report_func(
@@ -89,7 +53,7 @@ async def generate_report_func(
     format: str = "markdown"
 ) -> Dict[str, Any]:
     """
-    [空實作] 生成事後複盤報告。
+    生成事後複盤報告。
     
     Args:
         incident_data: 事件數據
@@ -98,68 +62,24 @@ async def generate_report_func(
     Returns:
         生成的報告內容
     """
-    print("--- [TOOL EXECUTED] generate_report_func: Generating mock report. ---")
+    remote_tool = RemoteTool(
+        tool_id="reporting.report_generator",
+        tool_version="0.1.0"
+    )
     
-    analysis_summary = incident_data.get('analysis_summary', '分析總結未提供。')
-    incident_id = incident_data.get('incident_id', 'UNKNOWN-INCIDENT')
-    service_name = incident_data.get('service_name', 'unknown-service')
-    
-    report_content = f"""# 事後複盤報告 (模擬)
-
-## 事件資訊
-- **事件 ID**: {incident_id}
-- **受影響服務**: {service_name}
-- **報告生成時間**: 模擬時間戳
-
-## 根本原因分析
-
-{analysis_summary}
-
-## 改善建議 (佔位)
-
-1. 增加服務器資源監控告警。
-2. 對相關服務進行壓力測試。
-3. 建立自動擴容機制，防止資源耗盡。
-4. 實施更嚴格的負載均衡策略。
-
-## 預防措施
-
-- 設定 CPU 使用率告警閾值為 80%
-- 建立延遲監控儀表板
-- 定期進行災難復原演練
-
----
-*本報告由 DetectViz 平台自動生成*
-"""
-    
-    # 模擬生成延遲
-    await asyncio.sleep(1)
-    return {
-        "status": "success",
-        "report_content": report_content.strip(),
-        "format": format,
-        "incident_id": incident_id
-    }
-    
-    # 原有的 RemoteTool 程式碼保留但註解掉
-    # remote_tool = RemoteTool(
-    #     tool_id="reporting.report_generator", 
-    #     tool_version="0.1.0"
-    # )
-    # 
-    # try:
-    #     result = await remote_tool.invoke({
-    #         "action": "generate_report",
-    #         "data": incident_data,
-    #         "format": format
-    #     })
-    #     return result
-    # except Exception as e:
-    #     return {
-    #         "status": "error",
-    #         "error_message": str(e),
-    #         "format": format
-    #     }
+    try:
+        # Go 插件可能期望直接的資料結構
+        payload = {
+            "incident_data": incident_data,
+            "format": format
+        }
+        return await remote_tool.invoke(payload)
+    except Exception as e:
+        return {
+            "status": "error",
+            "error_message": str(e),
+            "format": format
+        }
 
 
 async def create_dashboard_func(

--- a/python-adk-runtime/src/detectviz_adk/tools/remote_tool.py
+++ b/python-adk-runtime/src/detectviz_adk/tools/remote_tool.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 import asyncio
+import base64
 from typing import Any, Dict, Optional, List, Tuple
 
 import grpc
@@ -87,25 +88,29 @@ class RemoteTool(BaseTool):
         addr = os.getenv("DETECTVIZ_TOOLBRIDGE_ADDR") or get_toolbridge_addr()
         insecure = _env_bool("DETECTVIZ_TOOLBRIDGE_INSECURE", default=False)
 
-        cert = os.getenv("DETECTVIZ_TOOLBRIDGE_TLS_CERT")
-        key = os.getenv("DETECTVIZ_TOOLBRIDGE_TLS_KEY")
-        ca = os.getenv("DETECTVIZ_TOOLBRIDGE_TLS_CA")
+        # 直接從環境變數讀取 PEM 內容 (可以是 base64 編碼)
+        cert_pem_str = os.getenv("DETECTVIZ_TOOLBRIDGE_TLS_CERT_PEM")
+        key_pem_str = os.getenv("DETECTVIZ_TOOLBRIDGE_TLS_KEY_PEM")
+        ca_pem_str = os.getenv("DETECTVIZ_TOOLBRIDGE_TLS_CA_PEM")
 
-        if cert and key:  # 優先 mTLS/單向 TLS
-            with open(cert, "rb") as f:
-                cert_pem = f.read()
-            with open(key, "rb") as f:
-                key_pem = f.read()
-            root = None
-            if ca:
-                with open(ca, "rb") as f:
-                    root = f.read()
-            creds = grpc.ssl_channel_credentials(root_certificates=root, private_key=key_pem, certificate_chain=cert_pem)
+        cert_pem, key_pem, ca_pem = None, None, None
+
+        if cert_pem_str:
+            cert_pem = _decode_pem(cert_pem_str)
+        if key_pem_str:
+            key_pem = _decode_pem(key_pem_str)
+        if ca_pem_str:
+            ca_pem = _decode_pem(ca_pem_str)
+
+        if cert_pem and key_pem:  # mTLS/TLS 優先
+            creds = grpc.ssl_channel_credentials(
+                root_certificates=ca_pem, private_key=key_pem, certificate_chain=cert_pem
+            )
             self._channel = grpc.aio.secure_channel(addr, creds)
         elif insecure:
             self._channel = grpc.aio.insecure_channel(addr)
         else:
-            # 無憑證但也未明確允許明文 → 開發環境預設允許，生產環境請設定憑證或 INSECURE=true
+            # 若無憑證也未明確設為 insecure，則預設為 insecure (適用於本地開發)
             self._channel = grpc.aio.insecure_channel(addr)
 
         self._stub = pbg.ToolBridgeStub(self._channel)  # type: ignore
@@ -229,3 +234,14 @@ def _env_bool(key: str, default: bool = False) -> bool:
         return default
     s = v.strip().lower()
     return s in ("1", "true", "t", "yes", "y", "on")
+
+
+def _decode_pem(pem_str: str) -> bytes:
+    """解碼 PEM 字串，可處理可選的 base64 編碼。"""
+    if "-----BEGIN" in pem_str:
+        return pem_str.encode("utf-8")
+    try:
+        return base64.b64decode(pem_str)
+    except (ValueError, TypeError):
+        # Return as is if not valid base64
+        return pem_str.encode("utf-8")


### PR DESCRIPTION
This commit updates the `contracts/samples/config.yaml` file to use the new `cert_path`, `key_path`, and `ca_path` keys.

This was missed in the previous refactoring and ensures that the sample configuration is consistent with the updated Go config struct and JSON schema.