### PR TITLE
Fix multiple toolchain and plugin issues

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -10,13 +10,7 @@ PROTOC_GEN_PYTHON_VERSION := v5.28.3
 check-versions:
 	@echo "Checking tool versions..."
 	@command -v buf >/dev/null 2>&1 || { echo "buf not found. Run 'make install-tools' first."; exit 1; }
-	@BUF_ACTUAL=$$(buf --version 2>&1 | grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1); \
-	if [ "$$BUF_ACTUAL" != "$(BUF_VERSION)" ]; then \
-		echo "WARNING: buf version mismatch. Expected: $(BUF_VERSION), Found: $$BUF_ACTUAL"; \
-		echo "Run 'make install-tools' to install correct versions."; \
-	else \
-		echo "✓ buf version: $$BUF_ACTUAL"; \
-	fi
+	@BUF_ACTUAL_VERSION=$$(buf --version); 	BUF_ACTUAL_NUM=$$(echo $$BUF_ACTUAL_VERSION | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1); 	EXPECTED_NUM=$$(echo "$(BUF_VERSION)" | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+'); 	if [ "$$BUF_ACTUAL_NUM" != "$$EXPECTED_NUM" ]; then 		echo "WARNING: buf version mismatch. Expected: $(BUF_VERSION), Found: $$BUF_ACTUAL_VERSION"; 		echo "Run 'make install-tools' to install correct versions."; 	else 		echo "✓ buf version: $(BUF_VERSION)"; 	fi
 
 ## Install required tools with pinned versions
 install-tools:

--- a/contracts/tools/proto_health_check.py
+++ b/contracts/tools/proto_health_check.py
@@ -161,24 +161,44 @@ class ProtoHealthChecker:
                         self.issues.append(f"RPC {method_name} 的響應類型應該是 {expected_response}，而不是 {response_type}")
     
     def _check_unused_imports(self, lines: List[str], content: str):
-        """檢查未使用的 import"""
-        imports = []
-        
-        for line in lines:
+        """檢查未使用的 import（改進版）"""
+        imports = {}  # Store path and line number
+
+        for i, line in enumerate(lines):
             line = line.strip()
             import_match = re.match(r'import\s+"([^"]+)";', line)
             if import_match:
                 import_path = import_match.group(1)
-                imports.append(import_path)
-        
+                imports[import_path] = i
+
+        # 創建一個不包含 import 行的內容版本，以避免自我匹配
+        content_without_imports = "\n".join([
+            line for i, line in enumerate(lines) if i not in imports.values()
+        ])
+
         for import_path in imports:
-            # 提取文件名作為檢查依據
-            filename = import_path.split('/')[-1].replace('.proto', '')
+            # 提取基本文件名作為檢查依據
+            base_filename = import_path.split('/')[-1].replace('.proto', '')
+
+            # 啟發式：將文件名轉換為 PascalCase 作為潛在的類型名稱
+            # e.g., 'google/protobuf/struct.proto' -> 'Struct'
+            # e.g., 'my_custom_message.proto' -> 'MyCustomMessage'
+            potential_type = self._to_pascal_case(base_filename)
             
-            # 檢查是否在 content 中被使用（簡化檢查）
-            if filename not in content or content.count(filename) <= 1:
+            # 檢查潛在類型是否在文件的其餘部分被使用
+            # 這是啟發式的，可能不完美，但比單純的文件名檢查要好
+            if potential_type not in content_without_imports:
                 self.issues.append(f"可能未使用的 import: {import_path}")
                 self.fixes.append(f"考慮移除未使用的 import: {import_path}")
+
+    def _to_pascal_case(self, snake_str: str) -> str:
+        """將 snake_case 或 camelCase 轉換為 PascalCase"""
+        # 處理 camelCase
+        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', snake_str)
+        # 處理 snake_case
+        s2 = re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+
+        return "".join(word.capitalize() for word in s2.split('_'))
 
 def main():
     """命令行接口"""

--- a/go-platform/internal/pluginhost/plugins/gateway/http_request/module.card.json
+++ b/go-platform/internal/pluginhost/plugins/gateway/http_request/module.card.json
@@ -23,7 +23,12 @@
   "observability": {
     "tags": {
       "plugin.id": "detectviz.plugins.http_request_gateway"
-    }
+    },
+    "metrics": [
+      "http_client_requests_total",
+      "http_client_request_duration_seconds",
+      "http_client_requests_in_flight"
+    ]
   },
   "x-detectviz": {
     "rate_limit": {

--- a/go-platform/internal/pluginhost/plugins/observability/health_aggregator/plugin.go
+++ b/go-platform/internal/pluginhost/plugins/observability/health_aggregator/plugin.go
@@ -16,16 +16,8 @@ import (
 
 // Plugin 實作健康聚合器插件，符合 Handler 介面
 type Plugin struct {
-	provider     metrics.MetricsProvider
-	logger       *zap.Logger
-	mu           sync.RWMutex
-	metricsCache map[string]*CachedMetrics
-}
-
-// CachedMetrics 快取的指標數據
-type CachedMetrics struct {
-	Data      *HealthQueryResponse `json:"data"`
-	Timestamp time.Time            `json:"timestamp"`
+	provider metrics.MetricsProvider
+	logger   *zap.Logger
 }
 
 // HealthQueryRequest 健康查詢請求
@@ -71,9 +63,8 @@ func New() *Plugin {
 	provider := factory.CreateMemoryProvider()
 
 	return &Plugin{
-		provider:     provider,
-		logger:       zap.NewNop(),
-		metricsCache: make(map[string]*CachedMetrics),
+		provider: provider,
+		logger:   zap.NewNop(),
 	}
 }
 
@@ -103,20 +94,11 @@ func (p *Plugin) Invoke(ctx context.Context, req *pb.InvokeRequest) (*pb.InvokeR
 		zap.Strings("metrics", queryReq.Metrics),
 	)
 
-	// 檢查快取
-	if cached := p.getCachedMetrics(queryReq.ServiceName); cached != nil {
-		p.logger.Debug("Returning cached metrics")
-		return p.buildResponse(cached.Data)
-	}
-
 	// 執行查詢
 	response, err := p.queryHealthMetrics(ctx, queryReq)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query health metrics: %w", err)
 	}
-
-	// 快取結果
-	p.cacheMetrics(queryReq.ServiceName, response)
 
 	return p.buildResponse(response)
 }
@@ -135,12 +117,6 @@ func (p *Plugin) CloseWithContext(ctx context.Context) error {
 	// 等待進行中的請求完成
 	done := make(chan error, 1)
 	go func() {
-		p.mu.Lock()
-		defer p.mu.Unlock()
-
-		// 清理快取
-		p.metricsCache = make(map[string]*CachedMetrics)
-
 		// 關閉 provider
 		if p.provider != nil {
 			if err := p.provider.Close(); err != nil {
@@ -298,35 +274,6 @@ func (p *Plugin) calculateStatistics(values []DataPoint) *Statistics {
 	}
 }
 
-// getCachedMetrics 獲取快取的指標
-func (p *Plugin) getCachedMetrics(serviceName string) *CachedMetrics {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-
-	cached, exists := p.metricsCache[serviceName]
-	if !exists {
-		return nil
-	}
-
-	// 檢查快取是否過期（5分鐘）
-	if time.Since(cached.Timestamp) > 5*time.Minute {
-		return nil
-	}
-
-	return cached
-}
-
-// cacheMetrics 快取指標數據
-func (p *Plugin) cacheMetrics(serviceName string, response *HealthQueryResponse) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	p.metricsCache[serviceName] = &CachedMetrics{
-		Data:      response,
-		Timestamp: time.Now(),
-	}
-}
-
 // buildResponse 建構回應
 func (p *Plugin) buildResponse(response *HealthQueryResponse) (*pb.InvokeResponse, error) {
 	// 序列化回應
@@ -351,15 +298,6 @@ func (p *Plugin) HealthCheck() error {
 	// 檢查 provider 是否可用
 	if p.provider == nil {
 		return fmt.Errorf("metrics provider 未初始化")
-	}
-
-	// 檢查快取大小是否過大
-	p.mu.RLock()
-	cacheSize := len(p.metricsCache)
-	p.mu.RUnlock()
-
-	if cacheSize > 1000 {
-		return fmt.Errorf("快取過大: %d entries", cacheSize)
 	}
 
 	return nil


### PR DESCRIPTION
This commit addresses four separate issues:

1.  **Go Plugin Stateful Design:** Removes the in-memory cache from the `HealthAggregator` Go plugin to make it stateless, adhering to the project's design principles.

2.  **Contracts Toolchain Fixes:**
    - Improves the unused import check in `proto_health_check.py` to use a PascalCase heuristic, reducing false positives.
    - Makes the `buf` version check in the `contracts/Makefile` more robust by comparing version numbers directly, avoiding errors from different `buf --version` output formats.

3.  **Missing Observability Metrics:** Adds suggested observability metrics (`http_client_requests_total`, etc.) to the `http_request` plugin's `module.card.json`.