### PR TITLE
修復 Go 編譯錯誤並移除未使用的程式碼

### DIFF
--- a/go-platform/internal/metrics/factory.go
+++ b/go-platform/internal/metrics/factory.go
@@ -2,9 +2,7 @@ package metrics
 
 import (
 	"context"
-	"math"
 	"math/rand"
-	"sort"
 	"sync"
 	"time"
 
@@ -110,7 +108,7 @@ func (p *MemoryProvider) generateTestData(metric string, timeRange TimeRange) []
 	step := time.Minute
 
 	for current.Before(timeRange.End) || current.Equal(timeRange.End) {
-		value := p.generateTestValue(metric, current)
+		value := p.generateTestValue(metric)
 		points = append(points, DataPoint{
 			Timestamp: current,
 			Value:     value,
@@ -122,7 +120,7 @@ func (p *MemoryProvider) generateTestData(metric string, timeRange TimeRange) []
 }
 
 // generateTestValue 生成測試值
-func (p *MemoryProvider) generateTestValue(metric string, timestamp time.Time) float64 {
+func (p *MemoryProvider) generateTestValue(metric string) float64 {
 	base := 0.0
 	amplitude := 1.0
 
@@ -146,29 +144,4 @@ func (p *MemoryProvider) generateTestValue(metric string, timestamp time.Time) f
 	// 添加隨機性
 	noise := (rand.Float64() - 0.5) * 0.1
 	return base + amplitude*rand.Float64() + noise
-}
-
-// percentile 計算百分位數 (根據 FIXME.md 優化)
-func (p *MemoryProvider) percentile(values []float64, percentile float64) float64 {
-	if len(values) == 0 {
-		return 0
-	}
-	
-	// 復製並排序
-	sorted := make([]float64, len(values))
-	copy(sorted, values)
-	sort.Float64s(sorted)
-	
-	// 使用線性插值方法計算更精確的百分位數
-	k := float64(len(sorted)-1) * percentile
-	f := math.Floor(k)
-	c := math.Ceil(k)
-	
-	if f == c {
-		return sorted[int(k)]
-	}
-	
-	d0 := sorted[int(f)] * (c - k)
-	d1 := sorted[int(c)] * (k - f)
-	return d0 + d1
 }

--- a/go-platform/internal/metrics/prometheus_provider.go
+++ b/go-platform/internal/metrics/prometheus_provider.go
@@ -104,8 +104,10 @@ type PrometheusProvider struct {
 	logger *zap.Logger
 
 	// 快取管理
-	cache   map[string]*CachedResult
-	cacheMu sync.RWMutex
+	cache      map[string]*CachedResult
+	cacheMu    sync.RWMutex
+	inflight   map[string]chan struct{} // 用於防止快取失效風暴
+	inflightMu sync.Mutex
 
 	// 並發控制
 	concurrencyLimiter chan struct{}
@@ -197,6 +199,7 @@ func NewPrometheusProvider(config *PrometheusConfig, logger *zap.Logger) (*Prome
 		config:             config,
 		logger:             logger,
 		cache:              make(map[string]*CachedResult),
+		inflight:           make(map[string]chan struct{}),
 		concurrencyLimiter: make(chan struct{}, config.Concurrency.MaxConcurrent),
 		cbState:            StateClosed,
 	}
@@ -240,38 +243,74 @@ func (p *PrometheusProvider) Query(ctx context.Context, query MetricQuery) (*Que
 	return result, nil
 }
 
-// executeQuery 執行實際的查詢邏輯
+// executeQuery 執行實際的查詢邏輯，包含 single-flight 機制防止快取失效風暴
 func (p *PrometheusProvider) executeQuery(ctx context.Context, query MetricQuery) (*QueryResult, error) {
-	// 檢查快取
-	if p.config.Cache.Enabled {
-		if cached := p.getCachedResult(query); cached != nil {
-			providerQueriesTotal.WithLabelValues("cache_hit").Inc()
-			providerCacheHitsTotal.Inc()
-			p.logger.Debug("returning cached result", zap.String("metric", query.Metric))
-			return cached, nil
+	if !p.config.Cache.Enabled {
+		// 如果快取未啟用，直接執行查詢
+		promQL := p.buildPromQL(query)
+		result, warnings, err := p.executePrometheusQuery(ctx, promQL, query.TimeRange, query.Step)
+		if err != nil {
+			return nil, err
 		}
-		providerCacheMissesTotal.Inc()
+		return p.convertResult(query, result, warnings), nil
 	}
 
-	// 構建 PromQL 查詢
+	// 1. 檢查快取
+	key := p.buildCacheKey(query)
+	if cached := p.getCachedResult(query); cached != nil {
+		providerQueriesTotal.WithLabelValues("cache_hit").Inc()
+		providerCacheHitsTotal.Inc()
+		p.logger.Debug("returning cached result", zap.String("key", key))
+		return cached, nil
+	}
+
+	// 2. Single-flight 邏輯
+	p.inflightMu.Lock()
+	ch, inFlight := p.inflight[key]
+	if inFlight {
+		// 如果有其他 goroutine 正在查詢此 key，等待結果
+		p.inflightMu.Unlock()
+		p.logger.Debug("waiting for in-flight query", zap.String("key", key))
+		select {
+		case <-ch:
+			// 查詢已完成，再次從快取中獲取
+			p.logger.Debug("in-flight query finished, retrying from cache", zap.String("key", key))
+			return p.getCachedResult(query), nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	// 標記此 key 為正在查詢中
+	ch = make(chan struct{})
+	p.inflight[key] = ch
+	p.inflightMu.Unlock()
+
+	// 確保無論如何都清理 in-flight 標記
+	defer func() {
+		p.inflightMu.Lock()
+		if c, ok := p.inflight[key]; ok {
+			close(c)
+			delete(p.inflight, key)
+		}
+		p.inflightMu.Unlock()
+	}()
+
+	// 3. 快取未命中，執行查詢
+	providerCacheMissesTotal.Inc()
 	promQL := p.buildPromQL(query)
 	if promQL == "" {
 		return nil, fmt.Errorf("failed to build valid PromQL query")
 	}
 
-	// 執行查詢
 	result, warnings, err := p.executePrometheusQuery(ctx, promQL, query.TimeRange, query.Step)
 	if err != nil {
 		return nil, err
 	}
 
-	// 轉換結果
+	// 4. 轉換並快取結果
 	queryResult := p.convertResult(query, result, warnings)
-
-	// 快取結果
-	if p.config.Cache.Enabled {
-		p.cacheResult(query, queryResult)
-	}
+	p.cacheResult(query, queryResult)
 
 	return queryResult, nil
 }

--- a/go-platform/internal/pluginhost/metrics.go
+++ b/go-platform/internal/pluginhost/metrics.go
@@ -69,14 +69,3 @@ func (r *Registry) UpdateMetrics() {
 		pluginHealthGauge.WithLabelValues(name).Set(float64(health))
 	}
 }
-
-// recordInvocation 記錄插件調用指標
-func (r *Registry) recordInvocation(pluginName string, duration float64, status string) {
-	pluginInvocationCounter.WithLabelValues(pluginName, status).Inc()
-	pluginInvocationDuration.WithLabelValues(pluginName).Observe(duration)
-}
-
-// recordHealthCheck 記錄健康檢查指標
-func (r *Registry) recordHealthCheck(pluginName string, duration float64) {
-	pluginHealthCheckDuration.WithLabelValues(pluginName).Observe(duration)
-}

--- a/go-platform/internal/pluginhost/plugins/observability/health_aggregator/plugin_test.go
+++ b/go-platform/internal/pluginhost/plugins/observability/health_aggregator/plugin_test.go
@@ -57,7 +57,6 @@ func TestPlugin_New(t *testing.T) {
 	assert.NotNil(t, plugin)
 	assert.NotNil(t, plugin.provider)
 	assert.NotNil(t, plugin.logger)
-	assert.NotNil(t, plugin.metricsCache)
 }
 
 func TestPlugin_Initialize(t *testing.T) {
@@ -159,69 +158,14 @@ func TestPlugin_Invoke(t *testing.T) {
 	}
 }
 
-func TestPlugin_Cache(t *testing.T) {
-	plugin := New()
-	logger := zaptest.NewLogger(t)
-	plugin.Initialize(logger)
-
-	serviceName := "test-service"
-
-	// 第一次查詢
-	request := HealthQueryRequest{
-		ServiceName: serviceName,
-		TimeRange:   "1h",
-		Metrics:     []string{"cpu_usage"},
-	}
-
-	reqBytes, err := json.Marshal(request)
-	require.NoError(t, err)
-
-	reqStruct := &structpb.Struct{}
-	err = reqStruct.UnmarshalJSON(reqBytes)
-	require.NoError(t, err)
-
-	req := &pb.InvokeRequest{
-		Payload: reqStruct,
-	}
-
-	// 執行第一次查詢
-	resp1, err := plugin.Invoke(context.Background(), req)
-	require.NoError(t, err)
-
-	// 檢查快取是否存在
-	cached := plugin.getCachedMetrics(serviceName)
-	assert.NotNil(t, cached)
-
-	// 執行第二次查詢（應該使用快取）
-	resp2, err := plugin.Invoke(context.Background(), req)
-	require.NoError(t, err)
-
-	// 兩次回應應該相同（因為使用了快取）
-	assert.Equal(t, resp1.Result, resp2.Result)
-}
-
 func TestPlugin_Close(t *testing.T) {
 	plugin := New()
 	logger := zaptest.NewLogger(t)
 	plugin.Initialize(logger)
 
-	// 添加一些快取數據
-	response := &HealthQueryResponse{
-		ServiceName: "test",
-		Metrics:     make(map[string]*MetricData),
-		Timestamp:   time.Now(),
-	}
-	plugin.cacheMetrics("test", response)
-
-	// 驗證快取存在
-	assert.NotEmpty(t, plugin.metricsCache)
-
 	// 關閉插件
 	err := plugin.Close()
 	assert.NoError(t, err)
-
-	// 驗證快取已清理
-	assert.Empty(t, plugin.metricsCache)
 }
 
 func TestPlugin_TimeRangeParsing(t *testing.T) {
@@ -320,11 +264,9 @@ func TestHealthAggregator_ProviderFailure(t *testing.T) {
 	}
 
 	// 2. Create the plugin and inject the mock provider
-	plugin := &Plugin{
-		provider:     mockProvider,
-		logger:       logger,
-		metricsCache: make(map[string]*CachedMetrics),
-	}
+	plugin := New()
+	plugin.provider = mockProvider
+	plugin.logger = logger
 
 	// 3. Call Invoke with a request for both metrics
 	request := HealthQueryRequest{

--- a/go-platform/internal/pluginhost/registry.go
+++ b/go-platform/internal/pluginhost/registry.go
@@ -278,7 +278,7 @@ func (r *Registry) checkPluginHealth(wrapper *PluginWrapper) {
 		err = healthAware.HealthCheck()
 	} else {
 		// 否則使用簡單的調用測試
-		err = r.simpleHealthCheck(wrapper)
+		err = r.simpleHealthCheck()
 	}
 
 	duration := time.Since(start)
@@ -305,7 +305,7 @@ func (r *Registry) checkPluginHealth(wrapper *PluginWrapper) {
 }
 
 // simpleHealthCheck 簡單的健康檢查（針對不支援 HealthAwareHandler 的插件）
-func (r *Registry) simpleHealthCheck(wrapper *PluginWrapper) error {
+func (r *Registry) simpleHealthCheck() error {
 	// 這裡可以實作基本的插件狀態檢查
 	// 例如檢查是否還能正常回應等
 	return nil


### PR DESCRIPTION
根據 FIXME.json 的內容，進行了以下修復：

1.  **修復 `health_aggregator` 插件測試**：
    - 移除了 `plugin_test.go` 中與快取相關的過時測試邏輯。
    - 這些測試因 `plugin.go` 中移除了快取功能而導致編譯失敗。
    - 此變更使測試與當前「無狀態插件」的設計原則保持一致。

2.  **移除未使用的程式碼**：
    - 清理了 `metrics` 和 `pluginhost` 套件中多個未使用的函式和參數，以提高程式碼品質和可維護性。

3.  **修復 `PrometheusProvider` 中的競爭條件**：
    - 在 `prometheus_provider.go` 中實作了 single-flight 機制，以解決並發查詢時的快取競爭條件問題。
    - 此修復解決了一個在 `TestPrometheusProvider_CacheConcurrency` 中發現的測試失敗。

4.  **處理了 Python 導入錯誤**：
    - `FIXME.json` 中提到的 Python 檔案不存在，因此註明此問題無法修復。

所有 Go 測試現在都已通過，確保了程式碼的穩定性。